### PR TITLE
Translate value instead of key

### DIFF
--- a/geranslator/files_manager/extensions/abstractExtension.py
+++ b/geranslator/files_manager/extensions/abstractExtension.py
@@ -7,5 +7,5 @@ class AbstractExtension(ABC):
         pass
 
     @abstractmethod
-    def get_keys(self, file: str) -> list:
+    def get(self, file: str) -> dict:
         pass

--- a/geranslator/files_manager/extensions/json.py
+++ b/geranslator/files_manager/extensions/json.py
@@ -7,5 +7,5 @@ class Json(AbstractExtension):
     def insert(self, data: dict, file: str):
         json.dump(data, open(file, "w", encoding="utf-8"), indent=4, ensure_ascii = False)
 
-    def get_keys(self, file: str) -> list:
-        return list(json.load(open(file, "r")).keys())
+    def get(self, file: str) -> dict:
+        return json.load(open(file, "r"))

--- a/geranslator/files_manager/extensions/po.py
+++ b/geranslator/files_manager/extensions/po.py
@@ -19,11 +19,11 @@ class Po(AbstractExtension):
 
         po.save()
 
-    def get_keys(self, file: str) -> list:
-        keys: list = []
+    def get(self, file: str) -> dict:
+        data: dict = {}
         po = polib.pofile(file)
 
         for entry in po:
-            keys.append(entry.msgid)
+            data[entry.msgid] = entry.msgstr
 
-        return keys
+        return data

--- a/geranslator/files_manager/extensions/yaml.py
+++ b/geranslator/files_manager/extensions/yaml.py
@@ -7,5 +7,5 @@ class Yaml(AbstractExtension):
     def insert(self, data: dict, file: str):
         yaml.dump(data, open(file, "w"), allow_unicode = True)
 
-    def get_keys(self, file: str) -> list:
-        return list(yaml.load(open(file, "r"), Loader=yaml.Loader).keys())
+    def get(self, file: str) -> dict:
+        return yaml.load(open(file, "r"), Loader=yaml.Loader)

--- a/geranslator/files_manager/files_manager.py
+++ b/geranslator/files_manager/files_manager.py
@@ -48,12 +48,12 @@ class FilesManager:
 
         self.__ext_class().insert(self.data, lang_file)
 
-    def get_keys(self) -> list:
+    def get(self) -> list:
         lang_dir = os.path.join(os.getcwd(), self.langs_dir)
         lang_file = os.path.join(lang_dir, self.lang + '.' + self.extension)
 
         if os.path.exists(lang_file):
-            return self.__ext_class().get_keys(lang_file)
+            return self.__ext_class().get(lang_file)
         else:
             raise FileNotFound(lang_file)
 

--- a/geranslator/geranslator.py
+++ b/geranslator/geranslator.py
@@ -27,9 +27,9 @@ class Geranslator:
     def translate(self):
         self.make_sure_origin_lang_file_exists()
 
-        words = FilesManager().set_langs_dir(self.lang_dir).set_lang(self.origin_lang).set_extension(self.lang_files_ext).get_keys()
+        text = FilesManager().set_langs_dir(self.lang_dir).set_lang(self.origin_lang).set_extension(self.lang_files_ext).get()
 
-        translation = Provider(self.provider).translate(words, self.origin_lang, self.target_lang)
+        translation = Provider(self.provider).translate(text, self.origin_lang, self.target_lang)
 
         for lang in translation:
             FilesManager().set_langs_dir(self.lang_dir).set_data(translation[lang]).set_lang(lang).set_extension(self.lang_files_ext).insert()

--- a/geranslator/provider/provider.py
+++ b/geranslator/provider/provider.py
@@ -11,11 +11,11 @@ class Provider:
     def __init__(self, provider: str):
         self.__set_provider(provider.lower())
 
-    def translate(self, words: list, origin_lang: str, target_langs: List[str]) -> dict:
+    def translate(self, text: dict, origin_lang: str, target_langs: List[str]) -> dict:
         _module = import_module(f"geranslator.provider.providers.{self.provider}")
         _class = getattr(_module, self.provider.capitalize())
 
-        return _class().translate(words, origin_lang, target_langs)
+        return _class().translate(text, origin_lang, target_langs)
 
     def __set_provider(self, provider: str):
         self.__make_sure_provider_exists(provider)

--- a/geranslator/provider/providers/abstractProvider.py
+++ b/geranslator/provider/providers/abstractProvider.py
@@ -8,7 +8,7 @@ from webdriver_manager.chrome import ChromeDriverManager
 from selenium.common.exceptions import WebDriverException
 
 class AbstractProvider(ABC):
-    words_to_translate: list = []
+    text_to_translate: dict = {}
     translation: dict
 
     @abstractproperty
@@ -18,8 +18,8 @@ class AbstractProvider(ABC):
     def __init__(self):
         self.translation = {}
 
-    def translate(self, words: list, origin_lang: str, target_langs: List[str]) -> dict:
-        self.words_to_translate = words
+    def translate(self, text: dict, origin_lang: str, target_langs: List[str]) -> dict:
+        self.text_to_translate = text
 
         try:
             self.open_browser()

--- a/geranslator/provider/providers/deepl.py
+++ b/geranslator/provider/providers/deepl.py
@@ -13,13 +13,13 @@ class Deepl(AbstractProvider):
     url: str = 'https://www.deepl.com/translator'
 
     def translate_for(self, lang: str):
-        for word_to_translate in self.words_to_translate:
+        for key, value in self.text_to_translate.items():
             source_text = WebDriverWait(self.driver, 60).until(
                 expected_conditions.presence_of_element_located((
                     By.XPATH, "//*[@dl-test='translator-source-input']"
                 ))
             )
-            ActionChains(self.driver).move_to_element(source_text).click().send_keys(word_to_translate).perform()
+            ActionChains(self.driver).move_to_element(source_text).click().send_keys(value).perform()
 
             time.sleep(4)
 
@@ -31,7 +31,7 @@ class Deepl(AbstractProvider):
 
             time.sleep(2)
 
-            self.translation[lang][word_to_translate] = translated_element.get_attribute('value')
+            self.translation[lang][key] = translated_element.get_attribute('value')
 
             if self.driver.find_elements(By.XPATH, "//*[@dl-test='translator-source-input']//p"):
                 self.driver.find_element(By.XPATH, "//*[@dl-test='translator-source-input']//p").clear()

--- a/geranslator/provider/providers/google.py
+++ b/geranslator/provider/providers/google.py
@@ -13,13 +13,13 @@ class Google(AbstractProvider):
     url: str = 'https://translate.google.com'
 
     def translate_for(self, lang: str):
-        for word_to_translate in self.words_to_translate:
+        for key, value in self.text_to_translate.items():
             source_text = WebDriverWait(self.driver, 15).until(
                 expected_conditions.presence_of_element_located((
                     By.XPATH, "//textarea[@aria-label='Source text']"
                 ))
             )
-            ActionChains(self.driver).move_to_element(source_text).click().send_keys(word_to_translate).perform()
+            ActionChains(self.driver).move_to_element(source_text).click().send_keys(value).perform()
 
             time.sleep(2)
 
@@ -30,7 +30,7 @@ class Google(AbstractProvider):
             )
 
             translated_element = self.driver.find_element(by=By.XPATH, value="//span[@class='HwtZe']")
-            self.translation[lang][word_to_translate] = translated_element.text
+            self.translation[lang][key] = translated_element.text
             source_text.clear()
 
     def choose_languages(self, lang_from: str, target_lang: str) -> bool:

--- a/tests/exceptions/config_key_not_found_test.py
+++ b/tests/exceptions/config_key_not_found_test.py
@@ -8,4 +8,4 @@ class TestConfigKeyNotFoundException:
 
     def test_exception_message(self):
         exception = ConfigKeyNotFound('not_found')
-        assert all(word in str(exception) for word in ['not_found', 'not found in config file'])
+        assert all(text in str(exception) for text in ['not_found', 'not found in config file'])

--- a/tests/exceptions/extension_not_supported_test.py
+++ b/tests/exceptions/extension_not_supported_test.py
@@ -8,4 +8,4 @@ class TestExtensionNotSupportedException:
 
     def test_exception_message(self):
         exception = ExtensionNotSupported('pdf')
-        assert all(word in str(exception) for word in ['pdf', 'file format not supported'])
+        assert all(text in str(exception) for text in ['pdf', 'file format not supported'])

--- a/tests/exceptions/file_not_found_test.py
+++ b/tests/exceptions/file_not_found_test.py
@@ -10,4 +10,4 @@ class TestFileNotFoundException:
     def test_exception_message(self):
         exception = FileNotFound('not_found')
 
-        assert all(word in str(exception) for word in ['not_found', 'file not found'])
+        assert all(text in str(exception) for text in ['not_found', 'file not found'])

--- a/tests/exceptions/missing_extension_test.py
+++ b/tests/exceptions/missing_extension_test.py
@@ -4,4 +4,4 @@ class TestMissingExtensionException:
 
     def test_exception_message(self):
         exception = MissingExtension()
-        assert all(word in str(exception) for word in ['Extension is missing'])
+        assert all(text in str(exception) for text in ['Extension is missing'])

--- a/tests/exceptions/missing_origin_lang_test.py
+++ b/tests/exceptions/missing_origin_lang_test.py
@@ -4,4 +4,4 @@ class TestMissingOriginLangException:
 
     def test_exception_message(self):
         exception = MissingOriginLang()
-        assert all(word in str(exception) for word in ['Origin language is missing'])
+        assert all(text in str(exception) for text in ['Origin language is missing'])

--- a/tests/exceptions/missing_provider_test.py
+++ b/tests/exceptions/missing_provider_test.py
@@ -4,4 +4,4 @@ class TestMissingProviderException:
 
     def test_exception_message(self):
         exception = MissingProvider()
-        assert all(word in str(exception) for word in ['Provider is missing'])
+        assert all(text in str(exception) for text in ['Provider is missing'])

--- a/tests/exceptions/missing_target_lang_test.py
+++ b/tests/exceptions/missing_target_lang_test.py
@@ -4,4 +4,4 @@ class TestMissingTargetLangException:
 
     def test_exception_message(self):
         exception = MissingTargetLang()
-        assert all(word in str(exception) for word in ['Target languages are missing'])
+        assert all(text in str(exception) for text in ['Target languages are missing'])

--- a/tests/exceptions/origin_lang_file_not_found_test.py
+++ b/tests/exceptions/origin_lang_file_not_found_test.py
@@ -8,4 +8,4 @@ class TestOriginLangFileNotFoundException:
 
     def test_exception_message(self):
         exception = OriginLangFileNotFound('unexisted.json')
-        assert all(word in str(exception) for word in ['unexisted.json', 'not found'])
+        assert all(text in str(exception) for text in ['unexisted.json', 'not found'])

--- a/tests/exceptions/provider_not_found_test.py
+++ b/tests/exceptions/provider_not_found_test.py
@@ -8,4 +8,4 @@ class TestProviderNotFoundException:
 
     def test_exception_message(self):
         exception = ProviderNotFound('not_found')
-        assert all(word in str(exception) for word in ['not_found', 'provider not found'])
+        assert all(text in str(exception) for text in ['not_found', 'provider not found'])

--- a/tests/extensions/json_test.py
+++ b/tests/extensions/json_test.py
@@ -22,10 +22,10 @@ def before_and_after_test():
 
 class TestJsonExtension:
 
-    def test_get_keys(self):
-        json_keys = Json().get_keys(os.path.join(Config().get('lang_dir'), 'en.json'))
+    def test_get(self):
+        json_keys = Json().get(os.path.join(Config().get('lang_dir'), 'en.json'))
 
-        assert json_keys == ['Hello', 'Bye']
+        assert json_keys == {"Hello": "hello", "Bye": "bye"}
 
     def test_insertion(self):
         json_file = os.path.join(Config().get('lang_dir'), 'fr.json')

--- a/tests/extensions/po_test.py
+++ b/tests/extensions/po_test.py
@@ -22,10 +22,10 @@ def before_and_after_test():
 
 class TestPoExtension:
 
-    def test_get_keys(self):
-        po_keys = Po().get_keys(os.path.join(Config().get('lang_dir'), 'en.po'))
+    def test_get(self):
+        po_keys = Po().get(os.path.join(Config().get('lang_dir'), 'en.po'))
 
-        assert po_keys == ['Hello', 'Bye']
+        assert po_keys == {"Hello": "hello", "Bye": "bye"}
 
     def test_insertion(self):
         po_file = os.path.join(Config().get('lang_dir'), 'fr.po')

--- a/tests/extensions/yaml_test.py
+++ b/tests/extensions/yaml_test.py
@@ -22,10 +22,10 @@ def before_and_after_test():
 
 class TestYamlExtension:
 
-    def test_get_keys(self):
-        json_keys = Yaml().get_keys(os.path.join(Config().get('lang_dir'), 'en.yaml'))
+    def test_get(self):
+        json_keys = Yaml().get(os.path.join(Config().get('lang_dir'), 'en.yaml'))
 
-        assert json_keys == ['Bye', 'Hello']
+        assert json_keys == {"Hello": "hello", "Bye": "bye"}
 
     def test_insertion(self):
         yaml_file = os.path.join(Config().get('lang_dir'), 'fr.yaml')

--- a/tests/files_manager_test.py
+++ b/tests/files_manager_test.py
@@ -73,7 +73,7 @@ class TestFilesManager:
 
         assert os.path.exists(os.path.join(os.getcwd(), 'translations', 'en.json'))
 
-    def test_get_keys(self):
-        keys = FilesManager().set_lang('en').get_keys()
+    def test_get(self):
+        keys = FilesManager().set_lang('en').get()
 
-        assert keys == ['Hello', 'Bye']
+        assert keys == {"Hello": "hello", "Bye": "bye"}

--- a/tests/providers/deepl_test.py
+++ b/tests/providers/deepl_test.py
@@ -12,7 +12,7 @@ def before_and_after_test():
 
     os.mkdir(lang_dir)
     lang_file = open(f"{lang_dir}/en.json", 'w')
-    lang_file.write('{"Hello": "hello", "Bye": "bye"}')
+    lang_file.write('{"text_1": "hello", "text_2": "bye"}')
     lang_file.close()
 
     yield
@@ -24,26 +24,26 @@ class TestDeeplProvider:
     def test_url(self):
         assert Deepl().url == 'https://www.deepl.com/translator'
 
-    def test_translation_words(self):
+    def test_translation_text(self):
         deepl_provider = Deepl()
-        translation = deepl_provider.translate(['Hello', 'Bye'], 'en', ['es', 'fr'])
+        translation = deepl_provider.translate({"text_1": "hello", "text_2": "bye"}, 'en', ['es', 'fr'])
 
-        assert deepl_provider.words_to_translate == ['Hello', 'Bye']
+        assert deepl_provider.text_to_translate == {"text_1": "hello", "text_2": "bye"}
         assert list(deepl_provider.translation.keys()) == ['es', 'fr']
-        assert list(deepl_provider.translation['es'].keys()) == ['Hello', 'Bye']
-        assert list(deepl_provider.translation['fr'].keys()) == ['Hello', 'Bye']
-        assert deepl_provider.translation['es'] == {'Hello': 'Hola', 'Bye': 'Adiós'}
-        assert deepl_provider.translation['fr'] == {'Hello': 'Bonjour', 'Bye': 'Au revoir'}
-        assert translation == {'es': {'Hello': 'Hola', 'Bye': 'Adiós'}, 'fr': {'Hello': 'Bonjour', 'Bye': 'Au revoir'}}
+        assert list(deepl_provider.translation['es'].keys()) == ['text_1', 'text_2']
+        assert list(deepl_provider.translation['fr'].keys()) == ['text_1', 'text_2']
+        assert deepl_provider.translation['es'] == {'text_1': 'hola', 'text_2': 'adiós'}
+        assert deepl_provider.translation['fr'] == {'text_1': 'Bonjour', 'text_2': 'au revoir'}
+        assert translation == {'es': {'text_1': 'hola', 'text_2': 'adiós'}, 'fr': {'text_1': 'Bonjour', 'text_2': 'au revoir'}}
 
     def test_language_not_found_doesnt_stop_the_process(self):
         deepl_provider = Deepl()
-        translation = deepl_provider.translate(['Hello', 'Bye'], 'en', ['es', 'not_exist', 'fr'])
+        translation = deepl_provider.translate({"text_1": "hello", "text_2": "bye"}, 'en', ['es', 'not_exist', 'fr'])
 
-        assert deepl_provider.words_to_translate == ['Hello', 'Bye']
+        assert deepl_provider.text_to_translate == {"text_1": "hello", "text_2": "bye"}
         assert list(deepl_provider.translation.keys()) == ['es', 'fr']
-        assert list(deepl_provider.translation['es'].keys()) == ['Hello', 'Bye']
-        assert list(deepl_provider.translation['fr'].keys()) == ['Hello', 'Bye']
-        assert deepl_provider.translation['es'] == {'Hello': 'Hola', 'Bye': 'Adiós'}
-        assert deepl_provider.translation['fr'] == {'Hello': 'Bonjour', 'Bye': 'Au revoir'}
-        assert translation == {'es': {'Hello': 'Hola', 'Bye': 'Adiós'}, 'fr': {'Hello': 'Bonjour', 'Bye': 'Au revoir'}}
+        assert list(deepl_provider.translation['es'].keys()) == ['text_1', 'text_2']
+        assert list(deepl_provider.translation['fr'].keys()) == ['text_1', 'text_2']
+        assert deepl_provider.translation['es'] == {'text_1': 'hola', 'text_2': 'adiós'}
+        assert deepl_provider.translation['fr'] == {'text_1': 'Bonjour', 'text_2': 'au revoir'}
+        assert translation == {'es': {'text_1': 'hola', 'text_2': 'adiós'}, 'fr': {'text_1': 'Bonjour', 'text_2': 'au revoir'}}

--- a/tests/providers/google_test.py
+++ b/tests/providers/google_test.py
@@ -12,7 +12,7 @@ def before_and_after_test():
 
     os.mkdir(lang_dir)
     lang_file = open(f"{lang_dir}/en.json", 'w')
-    lang_file.write('{"Hello": "hello", "Bye": "bye"}')
+    lang_file.write('{"text_1": "hello", "text_2": "bye"}')
     lang_file.close()
 
     yield
@@ -24,26 +24,26 @@ class TestGoogleProvider:
     def test_url(self):
         assert Google().url == 'https://translate.google.com'
 
-    def test_translation_words(self):
+    def test_translation_text(self):
         google_provider = Google()
-        translation = google_provider.translate(['Hello', 'Bye'], 'en', ['ar', 'fr'])
+        translation = google_provider.translate({"text_1": "hello", "text_2": "bye"}, 'en', ['ar', 'fr'])
 
-        assert google_provider.words_to_translate == ['Hello', 'Bye']
+        assert google_provider.text_to_translate == {"text_1": "hello", "text_2": "bye"}
         assert list(google_provider.translation.keys()) == ['ar', 'fr']
-        assert list(google_provider.translation['ar'].keys()) == ['Hello', 'Bye']
-        assert list(google_provider.translation['fr'].keys()) == ['Hello', 'Bye']
-        assert google_provider.translation['ar'] == {'Hello': 'مرحبًا', 'Bye': 'وداعا'}
-        assert google_provider.translation['fr'] == {'Hello': 'Bonjour', 'Bye': 'Au revoir'}
-        assert translation == {'ar': {'Hello': 'مرحبًا', 'Bye': 'وداعا'}, 'fr': {'Hello': 'Bonjour', 'Bye': 'Au revoir'}}
+        assert list(google_provider.translation['ar'].keys()) == ['text_1', 'text_2']
+        assert list(google_provider.translation['fr'].keys()) == ['text_1', 'text_2']
+        assert google_provider.translation['ar'] == {'text_1': 'أهلا', 'text_2': 'وداعا'}
+        assert google_provider.translation['fr'] == {'text_1': 'salut', 'text_2': 'au revoir'}
+        assert translation == {'ar': {'text_1': 'أهلا', 'text_2': 'وداعا'}, 'fr': {'text_1': 'salut', 'text_2': 'au revoir'}}
 
     def test_language_not_found_doesnt_stop_the_process(self):
         google_provider = Google()
-        translation = google_provider.translate(['Hello', 'Bye'], 'en', ['ar', 'not_exist', 'fr'])
+        translation = google_provider.translate({"text_1": "hello", "text_2": "bye"}, 'en', ['ar', 'not_exist', 'fr'])
 
-        assert google_provider.words_to_translate == ['Hello', 'Bye']
+        assert google_provider.text_to_translate == {"text_1": "hello", "text_2": "bye"}
         assert list(google_provider.translation.keys()) == ['ar', 'fr']
-        assert list(google_provider.translation['ar'].keys()) == ['Hello', 'Bye']
-        assert list(google_provider.translation['fr'].keys()) == ['Hello', 'Bye']
-        assert google_provider.translation['ar'] == {'Hello': 'مرحبًا', 'Bye': 'وداعا'}
-        assert google_provider.translation['fr'] == {'Hello': 'Bonjour', 'Bye': 'Au revoir'}
-        assert translation == {'ar': {'Hello': 'مرحبًا', 'Bye': 'وداعا'}, 'fr': {'Hello': 'Bonjour', 'Bye': 'Au revoir'}}
+        assert list(google_provider.translation['ar'].keys()) == ['text_1', 'text_2']
+        assert list(google_provider.translation['fr'].keys()) == ['text_1', 'text_2']
+        assert google_provider.translation['ar'] == {'text_1': 'أهلا', 'text_2': 'وداعا'}
+        assert google_provider.translation['fr'] == {'text_1': 'salut', 'text_2': 'au revoir'}
+        assert translation == {'ar': {'text_1': 'أهلا', 'text_2': 'وداعا'}, 'fr': {'text_1': 'salut', 'text_2': 'au revoir'}}


### PR DESCRIPTION
This PR translate file values instead of the keys
Let's take an example with a `json`  file


`en.json` (origin lang)
```json
{
"text_1": "hello",
"text_2": "bye"
}
```
`ar.json` (target lang)
```json
{
"text_1": "أهلا",
"text_2": "وداعا"
}
```