### PR TITLE
CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,13 @@ geranslator:
 geranslator
 ```
 ### Supported options
-- --provider        | -p : To specify provider.
-- --lang-dir        | -d : To specify translation files directory.
-- --extension       | -e : To specify translation files format.
-- --origin-lang     | -o : To specify the origin language.
-- --target-langs    | -t : To specify target languages.
+| option | short | description |
+|---|---|---|
+| --provider        | -p | To specify provider.|
+| --lang-dir        | -d | To specify translation files directory.|
+| --extension       | -e | To specify translation files format.|
+| --origin-lang     | -o | To specify the origin language.|
+| --target-langs    | -t | To specify target languages.|
 ```bash
 geranslator --provider=deepl --origin-lang=en --target-langs=es,pt
 ```

--- a/README.md
+++ b/README.md
@@ -29,6 +29,25 @@ geranslator:
 
 > supported providers: google, deepl
 # Usage
+## CLI
+```bash
+geranslator
+```
+### Supported options
+- --provider        | -p : To specify provider.
+- --lang-dir        | -d : To specify translation files directory.
+- --extension       | -e : To specify translation files format.
+- --origin-lang     | -o : To specify the origin language.
+- --target-langs    | -t : To specify target languages.
+```bash
+geranslator --provider=deepl --origin-lang=en --target-langs=es,pt
+```
+```bash
+geranslator -p deepl -o en -t es,pt
+```
+> **Note**
+> Keep in mind that default values are on `.geranslator-config.yaml`
+## IDE
 This will use the configuration as default
 ```python
     from geranslator import Geranslator

--- a/geranslator/command_line/__init__.py
+++ b/geranslator/command_line/__init__.py
@@ -1,0 +1,4 @@
+from .command_line import CommandLine
+
+def main():
+    CommandLine().main()

--- a/geranslator/command_line/command_line.py
+++ b/geranslator/command_line/command_line.py
@@ -1,5 +1,31 @@
-import sys
+import typer
+
+from typing import List
+from ..geranslator import Geranslator
+from ..config.config import Config
 
 class CommandLine:
+    app = typer.Typer()
+
     def main(self):
-        args = sys.argv[1:]
+        self.app()
+
+    @app.command()
+    @staticmethod
+    def translate(
+        provider: str = typer.Option(Config().get('provider'), '--provider', '-p'),
+        lang_dir: str = typer.Option(Config().get('lang_dir'), '--lang-dir', '-d'),
+        extension: str = typer.Option(Config().get('lang_files_ext'), '--extension', '-e'),
+        origin_lang: str = typer.Option(Config().get('origin_lang'), '--origin-lang', '-o'),
+        target_langs: List[str] = typer.Option(Config().get('target_langs'), '--target-langs', '-t')
+    ):
+        if ',' in target_langs[0]:
+            target_langs = target_langs[0].split(',')
+
+        geranslator = Geranslator()
+        geranslator.set_provider(provider)
+        geranslator.set_lang_dir(lang_dir)
+        geranslator.set_lang_files_extension(extension)
+        geranslator.set_origin_lang(origin_lang)
+        geranslator.set_target_lang(target_langs)
+        geranslator.translate()

--- a/geranslator/command_line/command_line.py
+++ b/geranslator/command_line/command_line.py
@@ -1,0 +1,5 @@
+import sys
+
+class CommandLine:
+    def main(self):
+        args = sys.argv[1:]

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,7 @@ install_requires =
     webdriver-manager==3.8.5
     polib==1.1.1
     types-polib==1.1.12
+    typer==0.7.0
 
 [options.extras_require]
 dev =

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,3 +46,7 @@ dev =
     mypy==0.991
     pre-commit==2.21.0
     pytest-mock==3.10.0
+
+[options.entry_points]
+console_scripts =
+    geranslator=geranslator.command_line:main


### PR DESCRIPTION
Translate using CLI 🥳 

## Options
| option | short | description |
|---|---|---|
| --provider        | -p | To specify provider.|
| --lang-dir        | -d | To specify translation files directory.|
| --extension       | -e | To specify translation files format.|
| --origin-lang     | -o | To specify the origin language.|
| --target-langs    | -t | To specify target languages.|

## Usage
- Use defaults in `.geranslator-config.yaml`
```bash
geranslator
```
- Customizable
```bash
geranslator --provider=deepl --origin-lang=en --target-langs=es,pt
```
```bash
geranslator -p deepl -o en -t es,pt
```