### PR TITLE
Support lang files names with prefix

### DIFF
--- a/geranslator/files_manager/files_manager.py
+++ b/geranslator/files_manager/files_manager.py
@@ -3,7 +3,6 @@ from importlib import import_module
 
 from ..config.config import Config
 from ..exceptions.ExtensionNotSupported import ExtensionNotSupported
-from ..exceptions.FileNotFound import FileNotFound
 
 
 class FilesManager:
@@ -11,7 +10,7 @@ class FilesManager:
     dir: str = os.path.dirname(os.path.realpath(__file__))
     langs_dir: str = Config().get("lang_dir")
     data: dict
-    lang: str
+    lang_file: str
     ext_aliases: dict = {
         "yaml": ["yml"],
     }
@@ -30,8 +29,8 @@ class FilesManager:
 
         return self
 
-    def set_lang(self, lang: str):
-        self.lang = lang
+    def set_lang_file(self, file: str):
+        self.lang_file = file
 
         return self
 
@@ -42,7 +41,7 @@ class FilesManager:
 
     def insert(self):
         lang_dir = os.path.join(os.getcwd(), self.langs_dir)
-        lang_file = os.path.join(lang_dir, self.lang + "." + self.extension)
+        lang_file = os.path.join(lang_dir, f"{self.lang_file}.{self.extension}")
 
         if not os.path.exists(lang_dir):
             os.makedirs(lang_dir)
@@ -50,13 +49,7 @@ class FilesManager:
         self.__ext_class().insert(self.data, lang_file)
 
     def get(self) -> list:
-        lang_dir = os.path.join(os.getcwd(), self.langs_dir)
-        lang_file = os.path.join(lang_dir, self.lang + "." + self.extension)
-
-        if os.path.exists(lang_file):
-            return self.__ext_class().get(lang_file)
-        else:
-            raise FileNotFound(lang_file)
+        return self.__ext_class().get(self.lang_file)
 
     def __make_sure_extension_is_supported(self, extension) -> bool:
         self.ext_reference = extension

--- a/geranslator/geranslator.py
+++ b/geranslator/geranslator.py
@@ -17,6 +17,7 @@ from .provider.provider import Provider
 class Geranslator:
     provider: str
     lang_dir: str
+    lang_file_prefix: str = ""
     lang_files_ext: str
     origin_lang: str
     target_lang: List[str] = []
@@ -35,8 +36,7 @@ class Geranslator:
 
         text = (
             FilesManager()
-            .set_langs_dir(self.lang_dir)
-            .set_lang(self.origin_lang)
+            .set_lang_file(self.origin_lang_file)
             .set_extension(self.lang_files_ext)
             .get()
         )
@@ -54,7 +54,9 @@ class Geranslator:
         for lang in translation:
             FilesManager().set_langs_dir(self.lang_dir).set_data(
                 translation[lang]
-            ).set_lang(lang).set_extension(self.lang_files_ext).insert()
+            ).set_lang_file(f"{self.lang_file_prefix}{lang}").set_extension(
+                self.lang_files_ext
+            ).insert()
 
         end = time.time()
         TermSpark().line().spark()
@@ -118,7 +120,21 @@ class Geranslator:
             self.lang_dir, f"{self.origin_lang}.{self.lang_files_ext}"
         )
 
-        return os.path.exists(self.origin_lang_file)
+        if not os.path.exists(self.lang_dir):
+            return False
+
+        if not os.path.exists(self.origin_lang_file):
+            for file in os.listdir(self.lang_dir):
+                if file.endswith(f"{self.origin_lang}.{self.lang_files_ext}"):
+                    self.origin_lang_file = os.path.join(self.lang_dir, file)
+                    self.lang_file_prefix = file.split(
+                        f"{self.origin_lang}.{self.lang_files_ext}"
+                    )[0]
+                    return True
+        else:
+            return True
+
+        return False
 
     def make_sure_origin_lang_file_exists(self):
         if not self.origin_lang_file_exists():

--- a/tests/files_manager_test.py
+++ b/tests/files_manager_test.py
@@ -49,11 +49,13 @@ class TestFilesManager:
 
         assert files_manager.data == {"Hello": "Bonjour", "Bye": "Au revoir"}
 
-    def test_set_lang(self):
+    def test_set_lang_file(self):
         files_manager = FilesManager()
-        files_manager.set_lang("en")
+        files_manager.set_lang_file(os.path.join(Config().get("lang_dir"), "en.yaml"))
 
-        assert files_manager.lang == "en"
+        assert files_manager.lang_file == os.path.join(
+            Config().get("lang_dir"), "en.yaml"
+        )
 
     def test_set_langs_dir(self):
         files_manager = FilesManager()
@@ -62,7 +64,7 @@ class TestFilesManager:
         assert files_manager.langs_dir == "translations"
 
     def test_data_insertion_default_extension(self):
-        FilesManager().set_data({"Hello": "Bonjour", "Bye": "Au revoir"}).set_lang(
+        FilesManager().set_data({"Hello": "Bonjour", "Bye": "Au revoir"}).set_lang_file(
             "en"
         ).insert()
 
@@ -77,11 +79,15 @@ class TestFilesManager:
     def test_data_insertion(self):
         FilesManager().set_langs_dir("translations").set_data(
             {"Hello": "Bonjour", "Bye": "Au revoir"}
-        ).set_lang("en").set_extension("json").insert()
+        ).set_lang_file("en").set_extension("json").insert()
 
         assert os.path.exists(os.path.join(os.getcwd(), "translations", "en.json"))
 
     def test_get(self):
-        data = FilesManager().set_lang("en").get()
+        data = (
+            FilesManager()
+            .set_lang_file(os.path.join(Config().get("lang_dir"), "en.json"))
+            .get()
+        )
 
         assert data == {"Hello": "hello", "Bye": "bye"}

--- a/tests/geranslator_prefixed_files_names_test.py
+++ b/tests/geranslator_prefixed_files_names_test.py
@@ -1,0 +1,35 @@
+import os
+import shutil
+
+import pytest
+import yaml
+
+from geranslator.config.config import Config
+from geranslator.geranslator import Geranslator
+
+
+@pytest.fixture(autouse=True)
+def before_and_after_test():
+    lang_dir = Config().get("lang_dir")
+
+    os.mkdir(lang_dir)
+    lang_file = open(f"{lang_dir}/messages.en.yaml", "w")
+    yaml.dump({"Hello": "hello", "Bye": "bye"}, lang_file, allow_unicode=True)
+    lang_file.close()
+
+    yield
+
+    shutil.rmtree(lang_dir)
+
+
+class TestGeranslatorPrefixedFilesNamesTest:
+    def test_default_translation(self):
+        Geranslator().set_lang_files_extension("yaml").translate()
+
+        for lang in Config().get("target_langs"):
+            assert os.path.exists(
+                os.path.join(
+                    Config().get("lang_dir"),
+                    "messages." + lang + ".yaml",
+                )
+            )


### PR DESCRIPTION
`messages.` prefix example.
```bash
.
├── translations
│   ├── messages.en.yaml
│   ├── messages.fr.yaml
│   └── ...
└── ...
```