### PR TITLE
Run docs workflow only on release

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   docs-deploy:
+    if: contains(github.event.head_commit.message, 'release')
     name: Deploy docs
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Run docs workflow only when commit contains `release` keyword in main branch.