### PR TITLE
Fix `Deepl` translations that starts with comma

### DIFF
--- a/geranslator/provider/providers/deepl.py
+++ b/geranslator/provider/providers/deepl.py
@@ -35,7 +35,10 @@ class Deepl(AbstractProvider):
         translated_element = self.driver.find_element(
             By.XPATH, "//*[@data-testid='translator-target-input']"
         )
+
         translation = translated_element.get_attribute("value").lower()
+        if text.strip().startswith(","):
+            translation = "," + translation
 
         self.clear_source_text()
 

--- a/geranslator/provider/providers/deepl.py
+++ b/geranslator/provider/providers/deepl.py
@@ -37,8 +37,10 @@ class Deepl(AbstractProvider):
         )
 
         translation = translated_element.get_attribute("value").lower()
-        if text.strip().startswith(","):
-            translation = "," + translation
+        lstriped_text = text.lstrip()
+        whitespace_striped_len = len(text) - len(lstriped_text)
+        if lstriped_text.startswith(","):
+            translation = " " * whitespace_striped_len + "," + translation
 
         self.clear_source_text()
 

--- a/tests/providers/deepl_test.py
+++ b/tests/providers/deepl_test.py
@@ -183,7 +183,7 @@ class TestDeeplProvider:
         }
         assert translation["translation"] == {
             "es": {
-                "morning": "buenos días:attribute1 nos vemos. :attribute2 ¡más tarde!"
+                "morning": "buenos días:attribute1, nos vemos. :attribute2 ¡más tarde!"
             },
-            "sv": {"morning": "god morgon:attribute1 , vi ses :attribute2 senare!"},
+            "sv": {"morning": "god morgon:attribute1, vi ses :attribute2 senare!"},
         }

--- a/tests/providers/deepl_test.py
+++ b/tests/providers/deepl_test.py
@@ -183,7 +183,7 @@ class TestDeeplProvider:
         }
         assert translation["translation"] == {
             "es": {
-                "morning": "buenos días:attribute1, nos vemos. :attribute2 ¡más tarde!"
+                "morning": "buenos días:attribute1 , nos vemos. :attribute2 ¡más tarde!"
             },
-            "sv": {"morning": "god morgon:attribute1, vi ses :attribute2 senare!"},
+            "sv": {"morning": "god morgon:attribute1 , vi ses :attribute2 senare!"},
         }


### PR DESCRIPTION
`Deepl` ignores the leading comma from texts. This PR fixes it.